### PR TITLE
Changes nonpunctuation to accept unicode characters

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1705,7 +1705,7 @@
 			return [31, (DPGlobal.isLeapYear(year) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
 		},
 		validParts: /dd?|DD?|mm?|MM?|yy(?:yy)?/g,
-		nonpunctuation: /[^ -\/:-@\[\u3400-\u9fff-`{-~\t\n\r]+/g,
+		nonpunctuation: /[^ -\/:-@\u5e74\u6708\u65e5\[-`{-~\t\n\r]+/g,
 		parseFormat: function(format){
 			if (typeof format.toValue === 'function' && typeof format.toDisplay === 'function')
                 return format;


### PR DESCRIPTION
Rejecting Unicode characters in `nonpunctuation` is added in !294 to support yyyy年mm月dd format. However rejecting all Unicode in the range \u3400 to \u9fff rejects names of Chinese months too. And calling parseDate with Chinese date having the month format as  MM results in today's date always irrespective of the date passed. Hence don't reject all the Unicode and reject only the three Unicode in Japanese date format.
